### PR TITLE
Skip spaces between begin/end command and the section name option

### DIFF
--- a/Text/LaTeX/Base/Parser.hs
+++ b/Text/LaTeX/Base/Parser.hs
@@ -116,6 +116,7 @@ env :: Parser LaTeX
 env = do
   _  <- char '\\'
   n  <- envName "begin"
+  skipSpace
   as <- fmap (fromMaybe []) cmdArgs
   b  <- envBody n 
   return $ TeXEnv (T.unpack n) as b
@@ -130,7 +131,7 @@ envName k = do
 
 envBody :: Text -> Parser LaTeX
 envBody n = mconcat <$> (bodyBlock n) `manyTill` endenv
-  where endenv = try $ string ("\\end{" <> n <> "}")
+  where endenv = try $ string ("\\end") >> skipSpace >> string ("{" <> n <> "}")
 
 bodyBlock :: Text -> Parser LaTeX
 bodyBlock n = do


### PR DESCRIPTION
LaTeX allows us to put spaces between `\begin` / `\end` command and the section name parameter. When parsing this the parser always fails. Skipping spaces fixes this.
