### PR TITLE
Add 'nameref' command to hyperref package

### DIFF
--- a/Text/LaTeX/Packages/Hyperref.hs
+++ b/Text/LaTeX/Packages/Hyperref.hs
@@ -14,6 +14,7 @@ module Text.LaTeX.Packages.Hyperref
  , hyperbaseurl
  , hyperimage
  , autoref
+ , nameref
    ) where
 
 import Text.LaTeX.Base.Syntax


### PR DESCRIPTION
Hi Daniel,

I'd like to add a nameref command to the hyperref package. According to http://en.wikibooks.org/wiki/LaTeX/Labels_and_Cross-referencing this command is in the nameref package, but it's automatically included when you use hyperref.

I've tested this command in my LaTeX gen code - seems to be working fine.

Best regards,
-Dmitry
