### PR TITLE
Change test name to more accurately reflect its intent.

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,7 +18,7 @@ main = defaultMain $ testGroup "HaTeX"
          \l1 l2 l3 -> l1 <> (l2 <> l3) == (l1 <> l2) <> (l3 :: LaTeX)
     ]
   , testGroup "Parser"
-    [ QC.testProperty "render . parse = id" $
+    [ QC.testProperty "render . parse . render = render" $
          \l -> let t = render (l :: LaTeX)
                in  fmap render (parseLaTeX t) == Right t
     ]


### PR DESCRIPTION
The "render . parse = id" test was actually checking if
"render . parse . render = render". In fact, render . parse /= id;
e.g.

    render . parse $ "  \foo  " = "\foo"