### PR TITLE
Some utility for primitive calculus operations

### DIFF
--- a/Text/LaTeX/Packages/AMSMath.hs
+++ b/Text/LaTeX/Packages/AMSMath.hs
@@ -44,7 +44,7 @@ module Text.LaTeX.Packages.AMSMath
  , tsum , sumFromTo
  , prod , prodFromTo
  , integral , integralFromTo
- , partial
+ , partial, totald
    -- ** Operator symbols
    -- *** Arithmetic
  , cdot , times , div_
@@ -449,6 +449,10 @@ integralFromTo x y = commS "int" !: x ^: y
 -- | Partial-differentiation symbol ∂
 partial :: LaTeXC l => l
 partial = comm0 "partial"
+
+-- | Total-differentiation (or integration-variable) symbol d (non-italic!)
+totald :: LaTeXC l => l
+totald = mathrm "d"
 
 ---- Operator symbols
 

--- a/Text/LaTeX/Packages/AMSMath.hs
+++ b/Text/LaTeX/Packages/AMSMath.hs
@@ -44,7 +44,7 @@ module Text.LaTeX.Packages.AMSMath
  , tsum , sumFromTo
  , prod , prodFromTo
  , integral , integralFromTo
- , partial, totald
+ , partial, totald, partialOf, totaldOf
    -- ** Operator symbols
    -- *** Arithmetic
  , cdot , times , div_
@@ -453,6 +453,14 @@ partial = comm0 "partial"
 -- | Total-differentiation (or integration-variable) symbol d (non-italic!)
 totald :: LaTeXC l => l
 totald = mathrm "d"
+
+-- | Partial-differentiation of variable, e.g. /∂x/.
+partialOf :: LaTeXC l => l -> l
+partialOf v = comm0 "partial" <> v
+
+-- | Total-differentiation of variable, or integration over variable, e.g. d/x/.
+totaldOf :: LaTeXC l => l -> l
+totaldOf v = mathrm "d" <> v
 
 ---- Operator symbols
 

--- a/Text/LaTeX/Packages/AMSMath.hs
+++ b/Text/LaTeX/Packages/AMSMath.hs
@@ -40,10 +40,11 @@ module Text.LaTeX.Packages.AMSMath
  , tsqrt
    -- ** Custom function symbols
  , operatorname
-   -- ** Sum/Integral symbols
+   -- ** Summation \/ integration \/ differentiation
  , tsum , sumFromTo
  , prod , prodFromTo
  , integral , integralFromTo
+ , partial
    -- ** Operator symbols
    -- *** Arithmetic
  , cdot , times , div_
@@ -444,6 +445,10 @@ integralFromTo :: LaTeXC l
                -> l -- ^ Upper limit of integration.
                -> l
 integralFromTo x y = commS "int" !: x ^: y
+
+-- | Partial-differentiation symbol ∂
+partial :: LaTeXC l => l
+partial = comm0 "partial"
 
 ---- Operator symbols
 

--- a/Text/LaTeX/Packages/AMSMath.hs
+++ b/Text/LaTeX/Packages/AMSMath.hs
@@ -444,7 +444,7 @@ integralFromTo :: LaTeXC l
                => l -- ^ Lower limit of integration.
                -> l -- ^ Upper limit of integration.
                -> l
-integralFromTo x y = commS "int" !: x ^: y
+integralFromTo x y = commS "int" <> commS "limits" !: x ^: y
 
 -- | Partial-differentiation symbol ∂
 partial :: LaTeXC l => l


### PR DESCRIPTION
The `\partial` symbol ∂ wasn't in the `AmsMath` module at all. Apart from adding it, I also put in a non-italic `d` (for total differentiation `dy/dx`, or integrals `∫ f(x) dx`). Also, I don't like how `integralFromTo` worked: `\int_a^b` just adds `a` and `b` as sub/superscripts, _right_ of the integration symbol. To make them appear _above and below_ the symbol, like with sums, we need to write `\int\limits_a^b`; I made that the default.