### PR TITLE
Added .gitignore file to simplify haskell development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+dist
+.cabal-sandbox/
+cabal.sandbox.config
+*.hi
+*.o
+*.exe


### PR DESCRIPTION
This is a very basic gitignore file. It makes git much easier to use from the command line alongside cabal sandboxes.