### PR TITLE
Added package options for the hyperref package related to PDF metadata.

### DIFF
--- a/Text/LaTeX/Packages/Hyperref.hs
+++ b/Text/LaTeX/Packages/Hyperref.hs
@@ -15,12 +15,26 @@ module Text.LaTeX.Packages.Hyperref
  , hyperimage
  , autoref
  , nameref
+   -- * Package options
+ , pdftex
+ , pdftitle
+ , pdfauthor
+ , pdfsubject
+ , pdfcreator
+ , pdfproducer
+ , pdfkeywords
+ , pdftrapped
+ , pdfstartpage
+ , pdfpagelayout
+ , PdfPageLayout(..)
    ) where
 
 import Text.LaTeX.Base.Syntax
 import Text.LaTeX.Base.Class
+import Text.LaTeX.Base.Commands
 import Text.LaTeX.Base.Render
 import Text.LaTeX.Base.Types
+import Data.Text (pack)
 
 -- | The 'hyperref' package.
 --
@@ -85,3 +99,58 @@ autoref l = fromLaTeX $ TeXComm "autoref" [ FixArg $ rendertex l ]
 --   included when importing 'hyperref'.
 nameref :: LaTeXC l => Label -> l
 nameref l = fromLaTeX $ TeXComm "nameref" [ FixArg $ rendertex l ]
+
+-- | Creates a single-parameter package option.
+packageOption :: LaTeXC l => Text -> l -> l
+packageOption n p = raw n <> raw "={" <> p <> raw "}"
+
+-- | This package option selects the pdfTeX backend for the Hyperref package.
+pdftex :: LaTeXC l => l
+pdftex = raw "pdftex"
+
+-- | This package option sets the document information Title field.
+pdftitle :: LaTeXC l => l -> l
+pdftitle = packageOption "pdftitle"
+
+-- | This package option sets the document information Author field.
+pdfauthor :: LaTeXC l => l -> l
+pdfauthor = packageOption "pdfauthor"
+
+-- | This package option sets the document information Subject field.
+pdfsubject :: LaTeXC l => l -> l
+pdfsubject = packageOption "pdfsubject"
+
+-- | This package option sets the document information Creator field.
+pdfcreator :: LaTeXC l => l -> l
+pdfcreator = packageOption "pdfcreator"
+
+-- | This package option sets the document information Producer field.
+pdfproducer :: LaTeXC l => l -> l
+pdfproducer = packageOption "pdfproducer"
+
+-- | This package option sets the document information Keywords field.
+pdfkeywords :: LaTeXC l => l -> l
+pdfkeywords = packageOption "pdfkeywords"
+
+-- | This package option sets the document information Trapped entry.
+-- An 'Nothing' value means, the entry is not set. 
+pdftrapped :: LaTeXC l => Maybe Bool -> l
+pdftrapped Nothing = packageOption "pdftrapped" mempty
+pdftrapped (Just t) = packageOption "pdftrapped" . raw . pack . show $ t
+
+-- | This package option determines on which page the PDF file is opened.
+pdfstartpage :: LaTeXC l => l -> l
+pdfstartpage = packageOption "pdfstartpage"
+
+-- | This package option sets the layout of PDF pages.
+pdfpagelayout :: LaTeXC l => PdfPageLayout -> l
+pdfpagelayout l = packageOption "pdfpagelayout" . raw . pack . show $ l
+
+-- | Specification for how pages of a PDF should be displayed.
+data PdfPageLayout = SinglePage -- ^ Displays a single page; advancing flips the page.
+                   | OneColumn -- ^ Displays a single page; advancing flips the page.
+                   | TwoColumnLeft -- ^ Displays the document in two columns, odd-numbered pages to the left.
+                   | TwoColumnRight -- ^ Displays the document in two columns, odd-numbered pages to the right.
+                   | TwoPageLeft -- ^ Displays two pages, odd-numbered pages to the left (since PDF 1.5).
+                   | TwoPageRight -- ^ Displays two pages, odd-numbered pages to the right (since PDF 1.5).
+  deriving (Eq, Ord, Read, Show)                   


### PR DESCRIPTION
This patch adds helper functions for setting options of the Hyperref package. These are the commonly used ones related to PDF metadata. To be truly comprehensive there are dozens of others related to viewport setting and default print options, but these are the commonly used ones.