### PR TITLE
added square braces

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -1,5 +1,5 @@
 Name: HaTeX
-Version: 3.16.2.0
+Version: 3.16.2.1
 Author: Daniel Díaz
 Category: LaTeX
 Build-type: Simple

--- a/Text/LaTeX/Base/Class.hs
+++ b/Text/LaTeX/Base/Class.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
@@ -25,6 +24,7 @@ module Text.LaTeX.Base.Class (
  , comm1
  , commS
  , braces
+ , squareBraces
  ) where
 
 import Text.LaTeX.Base.Syntax
@@ -93,3 +93,6 @@ commS = fromLaTeX . TeXCommS
 --
 braces :: LaTeXC l => l -> l
 braces = liftL TeXBraces
+
+squareBraces :: LaTeXC l => l -> l
+squareBraces l = raw "[" <> l <> raw "]"

--- a/Text/LaTeX/Base/Class.hs
+++ b/Text/LaTeX/Base/Class.hs
@@ -95,4 +95,4 @@ braces :: LaTeXC l => l -> l
 braces = liftL TeXBraces
 
 squareBraces :: LaTeXC l => l -> l
-squareBraces l = raw "[" <> l <> raw "]"
+squareBraces = liftL $ \l -> TeXRaw "[" <> l <> TeXRaw "]" 


### PR DESCRIPTION
This could be useful when defining fractions of whitespace.

For example: `4.0\baselineskip` won't compile but `[4.0\baselineskip]`
will.
