### PR TITLE
Increase upper bound of transformers

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -62,7 +62,7 @@ Library
   Build-depends: base == 4.*
                , bytestring >= 0.9.2.1 && < 0.11
                , text >= 0.11.2.3 && < 2
-               , transformers >= 0.2.2 && < 0.5
+               , transformers >= 0.2.2 && < 0.6
                , containers >= 0.4.2.1 && < 0.6
                , matrix
                  -- Testing


### PR DESCRIPTION
Since GHC8 comes with transformers-0.5.2.0

This compiles with GHC 8.0.1-rc4.