### PR TITLE
Implement missing math space commands

### DIFF
--- a/Examples/mathSpaces.hs
+++ b/Examples/mathSpaces.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Text.LaTeX
+import Text.LaTeX.Packages.AMSMath
+
+main :: IO ()
+main = execLaTeXT mathSpaces >>= renderFile "mathSpaces.tex"
+
+mathSpaces :: Monad m => LaTeXT_ m
+mathSpaces = do
+ documentclass [] article
+ usepackage [] amsmath
+ document $
+   tabular Nothing [RightColumn, LeftColumn] $ do
+     texttt "quad"       & math ("H" >> quad       >> "H") ; lnbk
+     texttt "qquad"      & math ("H" >> qquad      >> "H") ; lnbk
+     texttt "thinspace"  & math ("H" >> thinspace  >> "H") ; lnbk
+     texttt "medspace"   & math ("H" >> medspace   >> "H") ; lnbk
+     texttt "thickspace" & math ("H" >> thickspace >> "H") ; lnbk
+     texttt "negspace"   & math ("H" >> negspace   >> "H") ; lnbk
+     texttt "space"      & math ("H" >> space      >> "H")

--- a/Text/LaTeX/Packages/AMSMath.hs
+++ b/Text/LaTeX/Packages/AMSMath.hs
@@ -119,6 +119,7 @@ module Text.LaTeX.Packages.AMSMath
  , v2matrix
    -- * Math spacing
  , quad, qquad
+ , thinspace, medspace, thickspace, negspace, space
    ) where
 
 import Text.LaTeX.Base
@@ -1055,14 +1056,22 @@ quad = comm0 "quad"
 qquad :: LaTeXC l => l
 qquad = comm0 "qquad"
 
-{-
-  The following commands are pending. Someone needs to find suitable
-  names for them.
+-- | \, space equal to 3/18 of \quad (= 3 mu)
+thinspace :: LaTeXC l => l
+thinspace = comm0 ","
 
-  \, 				3/18 of \quad (= 3 mu)
-  \: 				4/18 of \quad (= 4 mu)
-  \; 				5/18 of \quad (= 5 mu)
-  \! 				-3/18 of \quad (= -3 mu)
-  \ (space after backslash!) 	equivalent of space in normal text
+-- | \: space equal to 4/18 of \quad (= 4 mu)
+medspace :: LaTeXC l => l
+medspace = comm0 ":"
 
--}
+-- | \: space equal to 5/18 of \quad (= 5 mu)
+thickspace :: LaTeXC l => l
+thickspace = comm0 ";"
+
+-- | \! space equal to -3/18 of \quad (= -3 mu)
+negspace :: LaTeXC l => l
+negspace = comm0 "!"
+
+-- | \ (space after backslash) equivalent of space in normal text
+space :: LaTeXC l => l
+space = comm0 " "


### PR DESCRIPTION
I have got some suggestions for the missing math space commands on [TeX, LaTeX and Friends](http://chat.stackexchange.com/transcript/message/30723213#30723213) chat.