### PR TITLE
Fix case of qrcode level option

### DIFF
--- a/Text/LaTeX/Packages/QRCode.hs
+++ b/Text/LaTeX/Packages/QRCode.hs
@@ -21,7 +21,6 @@ import Text.LaTeX.Base.Render
 import Text.LaTeX.Base.Types
 import Text.LaTeX.Base.Texy
 import qualified Data.Text as T
-import Data.Char (toLower)
 
 -- | qrcode package. Use it to import it like this:
 --
@@ -66,9 +65,9 @@ final = "draft"
 qr :: LaTeXC l => CodeOptions -> Text -> l
 qr opt payload = fromLaTeX $ TeXComm "qrcode" [opts, FixArg . raw . escape $ payload]
   where
-    opts = MOptArg [ if includePadding opt then "padding" else "tight" 
-                   , if link opt then "link" else "nolink" 
-                   , texy . ("level=" <>) . T.singleton . toLower . head . show . errorLevel $ opt 
+    opts = MOptArg [ if includePadding opt then "padding" else "tight"
+                   , if link opt then "link" else "nolink"
+                   , texy . ("level=" <>) . T.singleton . head . show . errorLevel $ opt
                    ]
 
 -- Helper functions for escaping code contents.


### PR DESCRIPTION
```
  qr CodeOptions{ includePadding = True
                , link = False
                , errorLevel = High} "Hello!"
```
currently generates the following Latex fragment:
```
\qrcode[padding,nolink,level=h]{Hello!}
```
which leads to the following logs at compile time:
```
<QR code requested for "Hello!
" in version 0-M.>
<Error-correction level increased from M to H at no cost.>
<Calculating QR code for "Hello!
" in version 1-H.>
```

Despite the `errorLevel = High`, Latex interprets the qrcode request as version `0-M`.

According to [qrcode documentation](http://ftp.math.purdue.edu/mirrors/ctan.org/macros/latex/contrib/qrcode/qrcode.pdf#3), the level has to be `L`, `M`, `Q` or `H`.

The issue was that the qrcode level generated by HaTeX was in lower case letter instead of a capital one.

With this patch, the above piece of HaTeX code now generates:
```
\qrcode[padding,nolink,level=H]{Hello!}
```
which leads to the following logs at compile time:
```
<QR code requested for "Hello!
" in version 0-H.>
<Calculating QR code for "Hello!
" in version 1-H.>
```

Now, Latex correctly interprets the qrcode request as version `0-H`.