### PR TITLE
Hashable instances for the LaTeX syntax.

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -64,6 +64,7 @@ Library
                , text >= 0.11.2.3 && < 2
                , transformers >= 0.2.2 && < 0.6
                , containers >= 0.4.2.1 && < 0.6
+               , hashable >= 1.2 && < 1.3
                , matrix
                  -- Testing
                , QuickCheck

--- a/Text/LaTeX/Base/Syntax.hs
+++ b/Text/LaTeX/Base/Syntax.hs
@@ -40,6 +40,7 @@ import Data.Data (Data)
 import Data.Typeable
 import GHC.Generics (Generic)
 import Test.QuickCheck
+import Data.Hashable
 
 -- | Measure units defined in LaTeX. Use 'CustomMeasure' to use commands like 'textwidth'.
 --   For instance:
@@ -341,3 +342,9 @@ instance Arbitrary TeXArg where
        5 -> do m <- choose (1,5)
                MParArg <$> vectorOf m arbitrary
        _ -> FixArg <$> arbitrary
+
+
+instance Hashable Measure
+instance Hashable MathType
+instance Hashable TeXArg
+instance Hashable LaTeX


### PR DESCRIPTION
This is useful mainly in that it allows using TeX snippets as keys in
quick-lookup hash maps.

The `hashable` package is only a light dependency and the instances are completely
`Generic`-derived, so this seems sensible enough.