### PR TITLE
Rudimentary binding to BibLaTeX package, and simple example.

### DIFF
--- a/Examples/biblatex.hs
+++ b/Examples/biblatex.hs
@@ -1,0 +1,48 @@
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+
+import Text.LaTeX
+import Text.LaTeX.Packages.BibLaTeX
+import Text.LaTeX.Packages.Inputenc
+import qualified "bibtex" Text.BibTeX.Entry as BibTeX
+import qualified "bibtex" Text.BibTeX.Format as BibTeX
+import System.IO (writeFile)
+import System.Process (callProcess)
+
+main :: IO ()
+main = do
+  execLaTeXT bibLaTeXExample >>= renderFile "biblatex.tex"
+  writeFile bibFile . unlines $ BibTeX.entry <$> exampleBibliography
+  mapM_ (`callProcess`["biblatex"]) ["pdflatex", "biber", "pdflatex"]
+
+bibFile = "biblatex-example.bib"
+
+bibLaTeXExample :: Monad m => LaTeXT_ m
+bibLaTeXExample = thePreamble >> document theBody
+
+thePreamble :: Monad m => LaTeXT_ m
+thePreamble = do
+ documentclass [] article
+ usepackage [utf8] inputenc
+ usepackage ["backend=biber"] biblatex
+ addbibresource bibFile
+ author "Justus Sageműller"
+ title "BibLaTeX example using HaTeX"
+
+theBody :: Monad m => LaTeXT_ m
+theBody = do
+ "Bib"<>latex<>cite "bibLaTeX-manual"
+ " is a package for creating references to literature listed in a Bib"<>tex<>" file"
+ " (extension "<>verb".bib"<>")."
+ printbibliography
+
+exampleBibliography :: [BibTeX.T]
+exampleBibliography =
+ [ BibTeX.Cons
+    "manual"
+    "bibLaTeX-manual"
+    [ ("author", "P Lehman and P Kime and A Boruvka and J Wright")
+    , ("title", "The biblatex Package. Programmable Bibliographies and Citations.")
+    , ("URL", "http://mirrors.ctan.org/macros/latex/contrib/biblatex/doc/biblatex.pdf") ]
+ ]

--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -95,6 +95,7 @@ Library
         Text.LaTeX.Packages.AMSThm
         Text.LaTeX.Packages.Babel
         Text.LaTeX.Packages.Beamer
+        Text.LaTeX.Packages.BibLaTeX
         Text.LaTeX.Packages.Color
         Text.LaTeX.Packages.Fancyhdr
         Text.LaTeX.Packages.Fontenc

--- a/Text/LaTeX/Packages/BibLaTeX.hs
+++ b/Text/LaTeX/Packages/BibLaTeX.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | <https://ctan.org/tex-archive/macros/latex/contrib/biblatex BibLaTeX>
+--   is a reference-citation package using @.bib@ files (BibTeX) but no extra style-files.
+--
+module Text.LaTeX.Packages.BibLaTeX
+ ( biblatex
+ , addbibresource
+ , cite
+ , printbibliography
+ ) where
+
+import Text.LaTeX.Base.Syntax
+import Text.LaTeX.Base.Class
+import Text.LaTeX.Base.Render
+import Text.LaTeX.Base.Types
+import Text.LaTeX.Base.Commands (cite)
+
+-- | BibLaTeX package. Use it to import it like this:
+--
+-- > usepackage [] biblatex
+biblatex :: PackageName
+biblatex = "biblatex"
+
+-- | Use a bibliography file as resource for reference information.
+addbibresource :: LaTeXC l => FilePath -> l
+addbibresource fp = fromLaTeX $ TeXComm "addbibresource" [FixArg $ TeXRaw $ fromString fp]
+
+printbibliography :: LaTeXC l => l
+printbibliography = comm0 "printbibliography"
+


### PR DESCRIPTION
I thought about what commands apart from the inevitable `addbibresource` and `printbibliography` should be in the module, but could not decide how deep to go down that rabbit hole.

What I would really like to add is a monad transformer that allows conveniently citing stuff by just giving a DOI and having the Haskell programm automatically look up the bibliography information. This should be doable in the way [the DOI package](http://hackage.haskell.org/package/doi-0.0.2/docs/DOI.html) does it. (But I reckon such a feature shouldn't be included in the HaTeX package, since it involves networking etc.?)