### PR TITLE
Devel/consequent semigroup

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -64,7 +64,6 @@ Library
                , text >= 0.11.2.3 && < 2
                , transformers >= 0.2.2 && < 0.6
                , containers >= 0.4.2.1 && < 0.6
-               , semigroups
                , hashable >= 1.2 && < 1.3
                , matrix
                  -- Testing
@@ -75,6 +74,8 @@ Library
                , wl-pprint-extras >= 3.5
   if impl(ghc < 7.6)
     build-depends: ghc-prim
+  if impl(ghc < 8.0)
+    build-depends: semigroups
   Exposed-modules:
     Text.LaTeX
       -- Base (Core of the library)

--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -64,6 +64,7 @@ Library
                , text >= 0.11.2.3 && < 2
                , transformers >= 0.2.2 && < 0.6
                , containers >= 0.4.2.1 && < 0.6
+               , semigroups
                , hashable >= 1.2 && < 1.3
                , matrix
                  -- Testing

--- a/Text/LaTeX/Base/Syntax.hs
+++ b/Text/LaTeX/Base/Syntax.hs
@@ -29,9 +29,7 @@ module Text.LaTeX.Base.Syntax
 import Data.Text (Text,pack)
 import qualified Data.Text
 import Data.Monoid
-#if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup as Semigroup
-#endif
 import Data.String
 import Control.Applicative
 import Control.Monad (replicateM)
@@ -117,10 +115,8 @@ instance Monoid LaTeX where
 (<>) = mappend
 #endif
 
-#if MIN_VERSION_base(4,9,0)
 instance Semigroup.Semigroup LaTeX where
   (<>) = mappend
-#endif
 
 -- | Method 'fromString' escapes LaTeX reserved characters using 'protectString'.
 instance IsString LaTeX where

--- a/Text/LaTeX/Base/Writer.hs
+++ b/Text/LaTeX/Base/Writer.hs
@@ -60,8 +60,9 @@ import Control.Arrow
 import Data.String
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
-import Control.Applicative
 #endif
+import Control.Applicative
+import qualified Data.Semigroup as Semigroup
 -- transformers
 import Control.Monad.Trans.Writer
 import Control.Monad.IO.Class
@@ -219,3 +220,6 @@ instance (Monad m, a ~ ()) => IsString (LaTeXT m a) where
 instance (Monad m, Monoid a) => Monoid (LaTeXT m a) where
  mempty = return mempty
  mappend = liftM2 mappend
+
+instance (Applicative m, Semigroup.Semigroup a) => Semigroup.Semigroup (LaTeXT m a) where
+  (<>) = liftA2 (Semigroup.<>)


### PR DESCRIPTION
GHC-8.4 will [make it necessary](https://ghc.haskell.org/trac/ghc/ticket/14191) that every `Monoid` has a `Semigroup` instance (and anyway this is a good idea). By depending on the [`semigroups`](http://hackage.haskell.org/package/semigroups) package, we can write those instances unconditionally even for older version that didn't have the module in `base`.