### PR TITLE
Fix the type of stretch

### DIFF
--- a/Text/LaTeX/Base/Commands.hs
+++ b/Text/LaTeX/Base/Commands.hs
@@ -740,7 +740,7 @@ hspace m = fromLaTeX $ TeXComm "hspace" [FixArg $ rendertex m]
 hspace_ :: LaTeXC l => Measure -> l
 hspace_ m = fromLaTeX $ TeXComm "hspace*" [FixArg $ rendertex m]
 
-stretch :: LaTeXC l => Int -> l
+stretch :: LaTeXC l => Double -> l
 stretch n = fromLaTeX $ TeXComm "stretch" [FixArg $ rendertex n]
 
 vspace :: LaTeXC l => Measure -> l


### PR DESCRIPTION
According to the [LaTeX/Lengths](https://en.wikibooks.org/wiki/LaTeX/Lengths), the argument of `stretch` can be a floating point number:

> The command `\stretch{factor}` generates a special rubber space where `factor` is a number, possibly a **float**.