### PR TITLE
Use Measure for the width of a multirow cell

### DIFF
--- a/Examples/multirow.hs
+++ b/Examples/multirow.hs
@@ -24,21 +24,25 @@ exampleBody = do
   par
   tabular Nothing [VerticalLine, CenterColumn, VerticalLine, CenterColumn, VerticalLine] $ do
     hline
-    multirow Nothing 4 Nothing "1in" Nothing "Common g text" & "Column g2a" <> lnbk
+    multirow Nothing 4 Nothing (In 1) Nothing "Common g text" &
+      "Column g2a" <> lnbk
     mempty & "Column g2b" <> lnbk
     mempty & "Column g2c" <> lnbk
     mempty & "Column g2d" <> lnbk
     hline
-    multirow Nothing 3 (Just (BigStruts 6)) "*" Nothing "Common g text" & ("Column g2a" <> bigstrut) <> lnbk <> cline 2 2
+    multirow Nothing 3 (Just (BigStruts 6)) (CustomMeasure "*") Nothing "Common g text" &
+      ("Column g2a" <> bigstrut) <> lnbk <> cline 2 2
     mempty & ("Column g2b" <> bigstrut) <> lnbk <> cline 2 2
     mempty & ("Column g2c" <> bigstrut) <> lnbk
     hline
-    multirow Nothing 4 (Just (BigStruts 8)) "1in" Nothing "Common g text, but a bit longer." & ("Column g2a" <> bigstrut) <> lnbk <> cline 2 2
+    multirow Nothing 4 (Just (BigStruts 8)) (In 1) Nothing "Common g text, but a bit longer." &
+      ("Column g2a" <> bigstrut) <> lnbk <> cline 2 2
     mempty & ("Column g2b" <> bigstrut) <> lnbk <> cline 2 2
     mempty & ("Column g2c" <> bigstrut) <> lnbk <> cline 2 2
     mempty & ("Column g2d" <> bigstrut) <> lnbk
     hline
-    multirow Nothing 4 Nothing "*" Nothing (minitab CenterColumn ("Common " <> lnbk <> "g text")) & "Column g2a" <> lnbk
+    multirow Nothing 4 Nothing (CustomMeasure "*") Nothing (minitab CenterColumn ("Common " <> lnbk <> "g text")) &
+      "Column g2a" <> lnbk
     mempty & "Column g2b" <> lnbk
     mempty & "Column g2c" <> lnbk
     mempty & "Column g2d" <> lnbk

--- a/Text/LaTeX/Packages/Multirow.hs
+++ b/Text/LaTeX/Packages/Multirow.hs
@@ -13,7 +13,7 @@ module Text.LaTeX.Packages.Multirow
 import Data.Monoid ((<>))
 import Data.Maybe (catMaybes)
 import Text.LaTeX.Base.Syntax (LaTeX(TeXComm), TeXArg(FixArg, OptArg))
-import Text.LaTeX.Base.Class (LaTeXC, liftL2)
+import Text.LaTeX.Base.Class (LaTeXC, liftL)
 import Text.LaTeX.Base.Types (PackageName, Pos, Measure)
 import Text.LaTeX.Base.Render (Render, render, rendertex)
 
@@ -46,19 +46,17 @@ multirow :: LaTeXC l =>
             Maybe Pos            -- ^ Optional vertical positioning of the text in the multirow block
          -> Double               -- ^ Number of rows to span
          -> Maybe BigStrutsCount -- ^ Optinal total number of uses of bigstrut within the rows being spanned
-         -> l                    -- ^ Width to which the text is to be set
+         -> Measure              -- ^ Width to which the text is to be set
          -> Maybe Measure        -- ^ Optinal length used to raise or lower the text
          -> l                    -- ^ Actual text of the construct
          -> l
 multirow mVPos nrows mBigstruts width mVMove text =
-  liftL2 (\l1 l2 ->
-            TeXComm "multirow" $ catMaybes  [ fmap (OptArg . rendertex) mVPos
-                                            , Just (FixArg . rendertex $ nrows)
-                                            , fmap (OptArg . rendertex) mBigstruts
-                                            , Just (FixArg l1)
-                                            , fmap (OptArg . rendertex) mVMove
-                                            , Just (FixArg l2)
-                                            ]
-         ) width text
-
--- | 
+  liftL (\l ->
+           TeXComm "multirow" $ catMaybes  [ fmap (OptArg . rendertex) mVPos
+                                           , Just (FixArg . rendertex $ nrows)
+                                           , fmap (OptArg . rendertex) mBigstruts
+                                           , Just (FixArg . rendertex $ width)
+                                           , fmap (OptArg . rendertex) mVMove
+                                           , Just (FixArg l)
+                                           ]
+        ) text


### PR DESCRIPTION
Just after submitting the PR that adds multirows, I think I have found a better type for the `multirow` function. Sorry for the inconvenience.

The width of a multirow cell can be a dimension or '*' (indicating
that the natural width of the text is to be used) or '=' (indicating
that the specified width of the column in which the multirow entry is
set should be used).

Because of those two special cases its type has initially been set as
'LaTeXC l => l'. But it can be 'Measure', which supports the special
cases as 'CustomMeasure' and better fits the purpose of the width
argument.