### PR TITLE
Add footnotemark, footnotetext, stepcounter, addtocounter and section…

### DIFF
--- a/Text/LaTeX/Base/Commands.hs
+++ b/Text/LaTeX/Base/Commands.hs
@@ -79,8 +79,11 @@ module Text.LaTeX.Base.Commands
  , part
  , chapter
  , section
+ , section'
  , subsection
+ , subsection'
  , subsubsection
+ , subsubsection'
  , paragraph
  , subparagraph
    -- ** Logos & symbols
@@ -215,6 +218,10 @@ module Text.LaTeX.Base.Commands
  , raggedleft
  , raggedright
  , footnote
+ , footnotemark
+ , footnotetext
+ , stepcounter
+ , addtocounter
  , protect
  , hyphenation
  , hyp
@@ -325,13 +332,25 @@ chapter = comm1 "chapter"
 section :: LaTeXC l => l -> l
 section = comm1 "section"
 
+-- | Start a new unnumbered section with a given title.
+section' :: LaTeXC l => l -> l
+section' = comm1 "section*"
+
 -- | Start a new subsection.
 subsection :: LaTeXC l => l -> l
 subsection = comm1 "subsection"
 
+-- | Start a new unnumbered subsection.
+subsection' :: LaTeXC l => l -> l
+subsection' = comm1 "subsection*"
+
 -- | Start a new sub/sub/section.
 subsubsection :: LaTeXC l => l -> l
 subsubsection = comm1 "subsubsection"
+
+-- | Start a new unnumbered sub/sub/section.
+subsubsection' :: LaTeXC l => l -> l
+subsubsection' = comm1 "subsubsection*"
 
 -- | Start a paragraph.
 paragraph :: LaTeXC l => l -> l
@@ -753,6 +772,23 @@ raggedright = comm0 "raggedright"
 
 footnote :: LaTeXC l => l -> l
 footnote = liftL $ \l -> TeXComm "footnote" [FixArg l]
+
+-- | Prints a foot note mark but without the actual footnote.
+footnotemark :: LaTeXC l => l
+footnotemark = comm0 "footnotemark"
+
+-- | Prints the footnote corresponding to the previous footnotemark.
+-- Useful when dealing with footnotes in tabular environment.
+footnotetext :: LaTeXC l => l -> l
+footnotetext = comm1 "footnotetext"
+
+-- | Increases by 1 the value of given counter
+stepcounter :: LaTeXC l => String -> l
+stepcounter = comm1 "stepcounter" . fromString
+
+-- | Increases by `n` the value of given counter `t`
+addtocounter :: LaTeXC l => String -> Int -> l
+addtocounter t n = comm2 "addtocounter" (fromString t) (fromString . show $ n)
 
 linespread :: LaTeXC l => Float -> l
 linespread x = fromLaTeX $ TeXComm "linespread" [FixArg $ rendertex x]


### PR DESCRIPTION
I had troubles with making footnotes inside tabular environment; footnotemark, footnotetext, stepcounter and addtocounter commands [turned out](https://stackoverflow.com/questions/2888817/footnotes-for-tables-in-latex) to be helpful.

Also, added section* equivalents.