### PR TITLE
Hlint improvements

### DIFF
--- a/Examples/matrices.hs
+++ b/Examples/matrices.hs
@@ -19,4 +19,4 @@ thePreamble = do
  usepackage [] amsmath
 
 theBody :: Monad m => LaTeXT_ m
-theBody = equation_ $ pmatrix Nothing $ (identity 5 :: Matrix Int)
+theBody = equation_ $ pmatrix Nothing (identity 5 :: Matrix Int)

--- a/Examples/multirow.hs
+++ b/Examples/multirow.hs
@@ -15,8 +15,7 @@ example = do
   document exampleBody
 
 minitab :: Monad m => TableSpec -> LaTeXT_ m -> LaTeXT_ m
-minitab tableSpec text =
-  tabular Nothing [tableSpec] text
+minitab tableSpec = tabular Nothing [tableSpec]
 
 exampleBody :: Monad m => LaTeXT_ m
 exampleBody = do

--- a/Text/LaTeX/Base/Commands.hs
+++ b/Text/LaTeX/Base/Commands.hs
@@ -1084,7 +1084,7 @@ matrixTabular :: (LaTeXC l, Texy a)
               -> Matrix a -- ^ Matrix of data
               -> l -- ^ Data organized in a tabular environment
 matrixTabular ts m =
-  let spec = VerticalLine : (intersperse VerticalLine $ replicate (ncols m) CenterColumn) ++ [VerticalLine]
+  let spec = VerticalLine : intersperse VerticalLine (replicate (ncols m) CenterColumn) ++ [VerticalLine]
   in  tabular Nothing spec $ mconcat
         [ hline
         , foldl1 (&) ts

--- a/Text/LaTeX/Base/Math.hs
+++ b/Text/LaTeX/Base/Math.hs
@@ -522,9 +522,7 @@ totaldOf v = mathrm "d" <> v
 notop :: LaTeXC l =>
          (l -> l -> l)
       ->  l -> l -> l
-notop op =
- \l1 l2 ->
-   (l1 <> commS "not") `op` l2
+notop op l1 l2 = (l1 <> commS "not") `op` l2
 
 infixl 6 +-, -+
 

--- a/Text/LaTeX/Base/Parser.hs
+++ b/Text/LaTeX/Base/Parser.hs
@@ -140,7 +140,7 @@ text = do
   case mbC of
     Nothing -> fail "text: Empty input."
     Just c | c `member` nottext -> fail "not text"
-           | otherwise          -> TeXRaw <$> takeTill (`elem` nottext)
+           | otherwise          -> TeXRaw <$> takeTill (`member` nottext)
 
 ------------------------------------------------------------------------
 -- Text without stopping on ']'

--- a/Text/LaTeX/Base/Parser.hs
+++ b/Text/LaTeX/Base/Parser.hs
@@ -56,6 +56,7 @@ import           Data.Functor(($>))
 import           Data.Monoid
 #endif
 import           Data.Maybe (fromMaybe)
+import           Data.Set(Set, fromList, member)
 import qualified Data.Text as T 
 
 import           Control.Applicative
@@ -126,18 +127,19 @@ latexBlockParser = foldr1 (<|>)
     ]
 -- Note: text stops on ']'; if the other parsers fail on the rest
 --       text2 handles it, starting with ']' 
-  
+
 ------------------------------------------------------------------------
 -- Text
 ------------------------------------------------------------------------
+nottext :: Set Char
+nottext = fromList "$%\\{]}"
+
 text :: Parser LaTeX
 text = do
   mbC <- peekChar
-  let nottext :: String
-      nottext = "$%\\{]}"
   case mbC of
     Nothing -> fail "text: Empty input."
-    Just c | c `elem` nottext -> fail "not text"
+    Just c | c `member` nottext -> fail "not text"
            | otherwise          -> TeXRaw <$> takeTill (`elem` nottext)
 
 ------------------------------------------------------------------------

--- a/Text/LaTeX/Base/Parser.hs
+++ b/Text/LaTeX/Base/Parser.hs
@@ -51,6 +51,7 @@ module Text.LaTeX.Base.Parser (
 import           Text.Parsec hiding ((<|>),many)
 import           Text.Parsec.Error
 import           Data.Char (toLower,digitToInt)
+import           Data.Functor(($>))
 #if !MIN_VERSION_base(4,11,0)
 import           Data.Monoid
 #endif
@@ -68,7 +69,7 @@ import           Text.LaTeX.Base.Render
 ------------------------------------------------------------------------
 
 -- | Configuration for the LaTeX parser.
-data ParserConf = ParserConf
+newtype ParserConf = ParserConf
   { -- | This is the list of names of the environments such that
     --   their content will be parsed verbatim.
     verbatimEnvironments :: [String]
@@ -132,7 +133,7 @@ latexBlockParser = foldr1 (<|>)
 text :: Parser LaTeX
 text = do
   mbC <- peekChar
-  let nottext :: [Char]
+  let nottext :: String
       nottext = "$%\\{]}"
   case mbC of
     Nothing -> fail "text: Empty input."
@@ -346,10 +347,10 @@ specials :: String
 specials = "'(),.-\"!^$&#{}%~|/:;=[]\\` "
 
 peekChar :: Parser (Maybe Char)
-peekChar = Just <$> (try $ lookAhead anyChar) <|> pure Nothing
+peekChar = Just <$> try (lookAhead anyChar) <|> pure Nothing
 
 atEnd :: Parser Bool
-atEnd = (eof *> pure True) <|> pure False
+atEnd = (eof $> True) <|> pure False
 
 takeTill :: (Char -> Bool) -> Parser Text
 takeTill p = T.pack <$> many (satisfy (not . p))

--- a/Text/LaTeX/Base/Pretty.hs
+++ b/Text/LaTeX/Base/Pretty.hs
@@ -63,7 +63,7 @@ docLaTeX (TeXComment t) =
   let ls = Data.Text.lines t
   in  if null ls
          then pretty '%' <> hardline
-         else (align $ vsep $ fmap (pretty . ("% "++) . unpack) ls) <> hardline
+         else align (vsep $ fmap (pretty . ("% "++) . unpack) ls) <> hardline
 docLaTeX (TeXSeq l1 l2) = docLaTeX l1 <> docLaTeX l2
 docLaTeX TeXEmpty = mempty
 

--- a/Text/LaTeX/Base/Syntax.hs
+++ b/Text/LaTeX/Base/Syntax.hs
@@ -180,7 +180,7 @@ matchCommand :: (String -> Bool) -> LaTeX -> [(String,[TeXArg])]
 matchCommand f (TeXComm str as) =
   let xs = concatMap (matchCommandArg f) as
   in  if f str then (str,as) : xs else xs
-matchCommand f (TeXCommS str) = if f str then [(str,[])] else []
+matchCommand f (TeXCommS str) = [(str, []) | f str]
 matchCommand f (TeXEnv _ as l) =
   let xs = concatMap (matchCommandArg f) as
   in  xs ++ matchCommand f l
@@ -324,9 +324,9 @@ arbitraryLaTeX inDollar = do
             TeXEnv <$> arbitraryName <*> vectorOf m arbitrary <*> arbitrary
     4 -> if inDollar
             then arbitraryLaTeX True
-            else do do m <- choose (0,3)
-                       let t = [Parentheses,Square,Dollar,DoubleDollar] !! m
-                       TeXMath <$> pure t <*> arbitraryLaTeX (t == Dollar || t == DoubleDollar)
+            else do m <- choose (0,3)
+                    let t = [Parentheses,Square,Dollar,DoubleDollar] !! m
+                    TeXMath <$> pure t <*> arbitraryLaTeX (t == Dollar || t == DoubleDollar)
     5 -> TeXLineBreak <$> arbitrary <*> arbitrary
     6 -> TeXBraces <$> arbitrary
     7 -> TeXComment <$> arbitraryRaw

--- a/Text/LaTeX/Base/Writer.hs
+++ b/Text/LaTeX/Base/Writer.hs
@@ -54,7 +54,7 @@ module Text.LaTeX.Base.Writer
    ) where
 
 -- base
-import Control.Monad (liftM2)
+import Control.Monad (liftM, liftM2)
 import Control.Arrow
 import Data.String
 #if !MIN_VERSION_base(4,8,0)
@@ -74,15 +74,14 @@ import Text.LaTeX.Base.Render
 import Text.LaTeX.Base.Warnings (Warning,checkAll,check)
 
 -- | 'WriterT' monad transformer applied to 'LaTeX' values.
-newtype LaTeXT m a =
-  LaTeXT { unwrapLaTeXT :: WriterT LaTeX m a }
+newtype LaTeXT m a = LaTeXT { unwrapLaTeXT :: WriterT LaTeX m a }
 
 instance Functor f => Functor (LaTeXT f) where
- fmap f = LaTeXT . fmap f . unwrapLaTeXT
+    fmap f = LaTeXT . fmap f . unwrapLaTeXT
 
 instance Applicative f => Applicative (LaTeXT f) where
- pure = LaTeXT . pure
- (LaTeXT f) <*> (LaTeXT x) = LaTeXT $ f <*> x
+    pure = LaTeXT . pure
+    (LaTeXT f) <*> (LaTeXT x) = LaTeXT $ f <*> x
 
 -- | Type synonym for empty 'LaTeXT' computations.
 type LaTeXT_ m = LaTeXT m ()
@@ -138,12 +137,12 @@ runLaTeXT = runWriterT . unwrapLaTeXT
 -- > myLaTeX = execLaTeXT anExample
 --
 execLaTeXT :: Monad m => LaTeXT m a -> m LaTeX
-execLaTeXT = fmap snd . runLaTeXT
+execLaTeXT = liftM snd . runLaTeXT
 
 -- | Version of 'execLaTeXT' with possible warning messages.
 --   This function applies 'checkAll' to the 'LaTeX' output.
 execLaTeXTWarn :: Monad m => LaTeXT m a -> m (LaTeX,[Warning])
-execLaTeXTWarn = fmap (id &&& check checkAll) . execLaTeXT
+execLaTeXTWarn = liftM (id &&& check checkAll) . execLaTeXT
 
 -- | This function run a 'LaTeXT' computation,
 --   lifting the result again in the monad.
@@ -160,7 +159,7 @@ extractLaTeX = LaTeXT . lift . runWriterT . unwrapLaTeXT
 -- is to implement the 'LaTeXC' instance of 'LaTeXT', which
 -- is closely related.
 extractLaTeX_ :: Monad m => LaTeXT m a -> LaTeXT m LaTeX
-extractLaTeX_ = fmap snd . extractLaTeX
+extractLaTeX_ = liftM snd . extractLaTeX
 
 -- | With 'textell' you can append 'LaTeX' values to the
 --   state of the 'LaTeXT' monad.

--- a/Text/LaTeX/Base/Writer.hs
+++ b/Text/LaTeX/Base/Writer.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE TypeFamilies, CPP #-}
 
 -- | The writer monad applied to 'LaTeX' values. Useful to compose 'LaTeX' values
@@ -55,7 +54,7 @@ module Text.LaTeX.Base.Writer
    ) where
 
 -- base
-import Control.Monad (liftM, liftM2)
+import Control.Monad (liftM2)
 import Control.Arrow
 import Data.String
 #if !MIN_VERSION_base(4,8,0)
@@ -139,12 +138,12 @@ runLaTeXT = runWriterT . unwrapLaTeXT
 -- > myLaTeX = execLaTeXT anExample
 --
 execLaTeXT :: Monad m => LaTeXT m a -> m LaTeX
-execLaTeXT = liftM snd . runLaTeXT
+execLaTeXT = fmap snd . runLaTeXT
 
 -- | Version of 'execLaTeXT' with possible warning messages.
 --   This function applies 'checkAll' to the 'LaTeX' output.
 execLaTeXTWarn :: Monad m => LaTeXT m a -> m (LaTeX,[Warning])
-execLaTeXTWarn = liftM (id &&& check checkAll) . execLaTeXT
+execLaTeXTWarn = fmap (id &&& check checkAll) . execLaTeXT
 
 -- | This function run a 'LaTeXT' computation,
 --   lifting the result again in the monad.
@@ -161,7 +160,7 @@ extractLaTeX = LaTeXT . lift . runWriterT . unwrapLaTeXT
 -- is to implement the 'LaTeXC' instance of 'LaTeXT', which
 -- is closely related.
 extractLaTeX_ :: Monad m => LaTeXT m a -> LaTeXT m LaTeX
-extractLaTeX_ = liftM snd . extractLaTeX
+extractLaTeX_ = fmap snd . extractLaTeX
 
 -- | With 'textell' you can append 'LaTeX' values to the
 --   state of the 'LaTeXT' monad.

--- a/Text/LaTeX/Packages/Graphicx.hs
+++ b/Text/LaTeX/Packages/Graphicx.hs
@@ -1,5 +1,4 @@
-
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
 
 -- | This module allows you to use the LaTeX /graphicx/ library in order to
 --   insert graphics in a document and perform some transformations.

--- a/Text/LaTeX/Packages/Graphicx.hs
+++ b/Text/LaTeX/Packages/Graphicx.hs
@@ -63,11 +63,11 @@ data IGOption =
 instance Render IGOption where
  render (IGWidth m) = "width=" <> render m
  render (IGHeight m) = "height=" <> render m
- render (KeepAspectRatio b) = "keepaspectratio=" <> fromString (fmap toLower $ show b)
+ render (KeepAspectRatio b) = "keepaspectratio=" <> fromString (toLower <$> show b)
  render (IGScale r) = "scale=" <> render r
  render (IGAngle a) = "angle=" <> render a
  render (IGTrim l b r t) = "trim=" <> renderChars ' ' [l,b,r,t]
- render (IGClip b) = "clip=" <> fromString (fmap toLower $ show b)
+ render (IGClip b) = "clip=" <> fromString (toLower <$> show b)
  render (IGPage p) = "page=" <> render p
 
 -- | Include an image in the document.

--- a/Text/LaTeX/Packages/Graphicx.hs
+++ b/Text/LaTeX/Packages/Graphicx.hs
@@ -28,6 +28,7 @@ import Text.LaTeX.Base.Render
 import Text.LaTeX.Base.Types
 --
 import Data.Char (toLower)
+import Data.Functor ((<$>))
 
 -- | The 'graphicx' package.
 --
@@ -76,7 +77,7 @@ includegraphics :: LaTeXC l =>
                 -> FilePath  -- ^ Image file
                 -> l
 includegraphics opts fp = fromLaTeX $ TeXComm "includegraphics"
- [ MOptArg $ fmap rendertex opts , FixArg $ TeXRaw $ fromString fp ]
+ [ MOptArg $ fmap rendertex opts, FixArg $ TeXRaw $ fromString fp ]
 
 -- | Rotate the content by the given angle in degrees.
 rotatebox :: LaTeXC l => Float -> l -> l

--- a/Text/LaTeX/Packages/Graphicx.hs
+++ b/Text/LaTeX/Packages/Graphicx.hs
@@ -28,7 +28,9 @@ import Text.LaTeX.Base.Render
 import Text.LaTeX.Base.Types
 --
 import Data.Char (toLower)
+#if !MIN_VERSION_base(4,8,0)
 import Data.Functor ((<$>))
+#endif
 
 -- | The 'graphicx' package.
 --

--- a/Text/LaTeX/Packages/Hyperref.hs
+++ b/Text/LaTeX/Packages/Hyperref.hs
@@ -143,7 +143,7 @@ pdfstartpage = packageOption "pdfstartpage"
 
 -- | This package option sets the layout of PDF pages.
 pdfpagelayout :: LaTeXC l => PdfPageLayout -> l
-pdfpagelayout l = packageOption "pdfpagelayout" . raw . pack . show $ l
+pdfpagelayout = packageOption "pdfpagelayout" . raw . pack . show
 
 -- | Specification for how pages of a PDF should be displayed.
 data PdfPageLayout = SinglePage -- ^ Displays a single page; advancing flips the page.

--- a/Text/LaTeX/Packages/Multirow.hs
+++ b/Text/LaTeX/Packages/Multirow.hs
@@ -50,7 +50,7 @@ multirow :: LaTeXC l =>
          -> Maybe Measure        -- ^ Optinal length used to raise or lower the text
          -> l                    -- ^ Actual text of the construct
          -> l
-multirow mVPos nrows mBigstruts width mVMove text =
+multirow mVPos nrows mBigstruts width mVMove =
   liftL (\l ->
            TeXComm "multirow" $ catMaybes  [ fmap (OptArg . rendertex) mVPos
                                            , Just (FixArg . rendertex $ nrows)
@@ -59,4 +59,4 @@ multirow mVPos nrows mBigstruts width mVMove text =
                                            , fmap (OptArg . rendertex) mVMove
                                            , Just (FixArg l)
                                            ]
-        ) text
+        )

--- a/Text/LaTeX/Packages/QRCode.hs
+++ b/Text/LaTeX/Packages/QRCode.hs
@@ -76,4 +76,4 @@ escape = T.concatMap handleChar
                      | otherwise   = T.singleton c
 
 isSpecial :: Char -> Bool
-isSpecial c = elem c ("#$&^_~% \\{}" :: String)
+isSpecial c = c `elem` ("#$&^_~% \\{}" :: String)

--- a/Text/LaTeX/Packages/TikZ/PathBuilder.hs
+++ b/Text/LaTeX/Packages/TikZ/PathBuilder.hs
@@ -44,11 +44,11 @@ import Control.Monad.Trans.State
 import Control.Applicative
 #endif
 
-data PathState = PS { currentPath :: TPath }
+newtype PathState = PS { currentPath :: TPath }
 
 -- | Use a /path builder/ to construct a value of type 'TPath'.
 --   Use 'bpath' for this purpose.
-data PathBuilder a = PB { pathBuilder :: State PathState a }
+newtype PathBuilder a = PB { pathBuilder :: State PathState a }
 
 -- Instances
 
@@ -73,16 +73,16 @@ pcycle = applyToPath Cycle
 
 -- | Line from the current point to the given one.
 line :: TPoint -> PathBuilder ()
-line p = applyToPath $ (`Line`p)
+line p = applyToPath (`Line` p)
 
 -- | Rectangle with the current point as one cornder and the given point
 --   as the opposite corner.
 rectangle :: TPoint -> PathBuilder ()
-rectangle p = applyToPath $ (`Rectangle`p)
+rectangle p = applyToPath (`Rectangle` p)
 
 -- | Circle with the given radius centered at the current point.
 circle :: Double -> PathBuilder ()
-circle r = applyToPath $ (`Circle`r)
+circle r = applyToPath (`Circle` r)
 
 -- | Ellipse with width and height described by the arguments and centered
 --   at the current point.

--- a/Text/LaTeX/Packages/TikZ/Syntax.hs
+++ b/Text/LaTeX/Packages/TikZ/Syntax.hs
@@ -151,7 +151,7 @@ data TPath =
                      -- point of @x@.
     deriving Show
 
-data GridOption =
+newtype GridOption =
    GridStep Step
    deriving Show
 

--- a/Text/LaTeX/Packages/Trees.hs
+++ b/Text/LaTeX/Packages/Trees.hs
@@ -29,4 +29,4 @@ instance Foldable Tree where
 
 instance Traversable Tree where
  sequenceA (Leaf fa) = Leaf <$> fa
- sequenceA (Node mfa ts) = liftA2 Node (sequenceA mfa) $ sequenceA $ fmap sequenceA ts
+ sequenceA (Node mfa ts) = liftA2 Node (sequenceA mfa) $ traverse sequenceA ts


### PR DESCRIPTION
After running `hlint` some suggestions showed up. The following suggestions have been ignored:

```
Examples/multirow.hs:28:5: Suggestion: Reduce duplication
Found:
  mempty & "Column g2b" <> lnbk
  mempty & "Column g2c" <> lnbk
  mempty & "Column g2d" <> lnbk
  hline
  
Why not:
  Combine with Examples/multirow.hs:45:5

Text/LaTeX/Base/Class.hs:56:26: Suggestion: Use const
Found:
  \ _ -> l
Why not:
  const l

Text/LaTeX/Base/Commands.hs:1167:1: Suggestion: Use camelCase
Found:
  hatex_version = ...
Why not:
  hatexVersion = ...

3 hints
```

(the `const` was already merged into the `master`)