### PR TITLE
WIP: First sketch of parametrizing the AST (followup on #148)

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -88,6 +88,7 @@ Library
         Text.LaTeX.Base.Pretty
         Text.LaTeX.Base.Render
         Text.LaTeX.Base.Syntax
+        Text.LaTeX.Base.Syntax.WithParm
         Text.LaTeX.Base.Texy
         Text.LaTeX.Base.Types
         Text.LaTeX.Base.Writer

--- a/Text/LaTeX/Base/Class.hs
+++ b/Text/LaTeX/Base/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP , TypeSynonymInstances , FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 -- | Definition of the 'LaTeXC' class, used to combine the classic applicative and

--- a/Text/LaTeX/Base/Math.hs
+++ b/Text/LaTeX/Base/Math.hs
@@ -1,6 +1,7 @@
-
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP               #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE CPP                  #-}
 
 -- | This module contains the maths-specific part of "Text.LaTeX.Base.Commands",
 --  i.e. of the commands that are available in LaTeX out of the box without

--- a/Text/LaTeX/Base/Render.hs
+++ b/Text/LaTeX/Base/Render.hs
@@ -22,7 +22,7 @@ module Text.LaTeX.Base.Render
  , showFloat
    ) where
 
-import Text.LaTeX.Base.Syntax
+import Text.LaTeX.Base.Syntax.WithParm
 import Text.LaTeX.Base.Class
 import Data.String
 import Data.List (intersperse)
@@ -105,12 +105,12 @@ readFileTex = fmap decodeUtf8 . B.readFile
 --
 -- /Warning: /'rendertex'/ does not escape LaTeX reserved characters./
 -- /Use /'protectText'/ to escape them./
-rendertex :: (Render a,LaTeXC l) => a -> l
-rendertex = fromLaTeX . TeXRaw . render
+rendertex :: (Render a, LaTeXC l) => a -> l
+rendertex = fromLaTeX . TeXRaw () . render
 
 -- Render instances
 
-instance Render Measure where
+instance (Show a) => Render (Measure a) where
  render (Pt x) = render x <> "pt"
  render (Mm x) = render x <> "mm"
  render (Cm x) = render x <> "cm"
@@ -121,18 +121,18 @@ instance Render Measure where
 
 -- LaTeX instances
 
-instance Render LaTeX where
+instance (Show a) => Render (LaTeX a) where
   
-  renderBuilder (TeXRaw t) = Builder.fromText t
+  renderBuilder (TeXRaw _ t) = Builder.fromText t
   
-  renderBuilder (TeXComm name []) = "\\" <> fromString name <> "{}"
-  renderBuilder (TeXComm name args) =
+  renderBuilder (TeXComm _ name []) = "\\" <> fromString name <> "{}"
+  renderBuilder (TeXComm _ name args) =
       "\\"
    <> fromString name
    <> renderAppendBuilder args
-  renderBuilder (TeXCommS name) = "\\" <> fromString name
+  renderBuilder (TeXCommS _ name) = "\\" <> fromString name
   
-  renderBuilder (TeXEnv name args c) =
+  renderBuilder (TeXEnv _ _ name args c) =
       "\\begin{"
    <> fromString name
    <> "}"
@@ -142,16 +142,16 @@ instance Render LaTeX where
    <> fromString name
    <> "}"
 
-  renderBuilder (TeXMath Dollar l) = "$" <> renderBuilder l <> "$"
-  renderBuilder (TeXMath DoubleDollar l) = "$$" <> renderBuilder l <> "$$"
-  renderBuilder (TeXMath Square l) = "\\[" <> renderBuilder l <> "\\]"
-  renderBuilder (TeXMath Parentheses l) = "\\(" <> renderBuilder l <> "\\)"
+  renderBuilder (TeXMath _ Dollar l) = "$" <> renderBuilder l <> "$"
+  renderBuilder (TeXMath _ DoubleDollar l) = "$$" <> renderBuilder l <> "$$"
+  renderBuilder (TeXMath _ Square l) = "\\[" <> renderBuilder l <> "\\]"
+  renderBuilder (TeXMath _ Parentheses l) = "\\(" <> renderBuilder l <> "\\)"
 
-  renderBuilder (TeXLineBreak m b) = "\\\\" <> maybe mempty (\x -> "[" <> renderBuilder x <> "]") m <> ( if b then "*" else mempty )
+  renderBuilder (TeXLineBreak _ m b) = "\\\\" <> maybe mempty (\x -> "[" <> renderBuilder x <> "]") m <> ( if b then "*" else mempty )
 
-  renderBuilder (TeXBraces l) = "{" <> renderBuilder l <> "}"
+  renderBuilder (TeXBraces _ l) = "{" <> renderBuilder l <> "}"
 
-  renderBuilder (TeXComment c) =
+  renderBuilder (TeXComment _ c) =
    let xs = Data.Text.lines c
    in if null xs then "%\n"
                  else Builder.fromText $ Data.Text.unlines $ fmap ("%" <>) xs
@@ -161,17 +161,17 @@ instance Render LaTeX where
 
   render = renderDefault
 
-instance Render TeXArg where
- renderBuilder (FixArg l) = "{" <> renderBuilder l <> "}"
- renderBuilder (OptArg l) = "[" <> renderBuilder l <> "]"
- renderBuilder (MOptArg []) = mempty
- renderBuilder (MOptArg ls) = "[" <> renderCommasBuilder ls <> "]"
- renderBuilder (SymArg l) = "<" <> renderBuilder l <> ">"
- renderBuilder (MSymArg []) = mempty
- renderBuilder (MSymArg ls) = "<" <> renderCommasBuilder ls <> ">"
- renderBuilder (ParArg l) = "(" <> renderBuilder l <> ")"
- renderBuilder (MParArg []) = mempty
- renderBuilder (MParArg ls) = "(" <> renderCommasBuilder ls <> ")"
+instance (Show a) => Render (TeXArg a) where
+ renderBuilder (FixArg _ l) = "{" <> renderBuilder l <> "}"
+ renderBuilder (OptArg _ l) = "[" <> renderBuilder l <> "]"
+ renderBuilder (MOptArg _ []) = mempty
+ renderBuilder (MOptArg _ ls) = "[" <> renderCommasBuilder ls <> "]"
+ renderBuilder (SymArg _ l) = "<" <> renderBuilder l <> ">"
+ renderBuilder (MSymArg _ []) = mempty
+ renderBuilder (MSymArg _ ls) = "<" <> renderCommasBuilder ls <> ">"
+ renderBuilder (ParArg _ l) = "(" <> renderBuilder l <> ")"
+ renderBuilder (MParArg _ []) = mempty
+ renderBuilder (MParArg _ ls) = "(" <> renderCommasBuilder ls <> ")"
  render = renderDefault
 
 -- Other instances

--- a/Text/LaTeX/Base/Syntax/WithParm.hs
+++ b/Text/LaTeX/Base/Syntax/WithParm.hs
@@ -1,0 +1,347 @@
+{-# LANGUAGE FlexibleInstances, CPP, DeriveDataTypeable, DeriveGeneric, DeriveFunctor #-}
+
+-- | LaTeX syntax description in the definition of the 'LaTeX' datatype.
+--   If you want to add new commands or environments not defined in
+--   the library, import this module and use 'LaTeX' data constructors.
+module Text.LaTeX.Base.Syntax.WithParm
+ ( -- * @LaTeX@ datatype
+   Measure (..)
+ , MathType (..)
+ , LaTeX (..)
+ , TeXArg (..)
+ , (<>), between
+   -- * Escaping reserved characters
+ , protectString
+ , protectText
+   -- * Syntax analysis
+ , matchCommand
+ , lookForCommand
+ , matchEnv
+ , lookForEnv
+ , texmap 
+ , texmapM
+   -- ** Utils
+ , getBody
+ , getPreamble
+   ) where
+
+import Data.Text (Text,pack)
+import qualified Data.Text
+import qualified Data.Semigroup as Semigroup
+import Data.String
+import Control.Applicative
+import Control.Monad (replicateM)
+import Data.Functor.Identity (runIdentity)
+import Data.Data (Data)
+import Data.Typeable
+import Test.QuickCheck
+import Data.Hashable
+import GHC.Generics (Generic)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid
+#endif
+
+-- | Measure units defined in LaTeX. Use 'CustomMeasure' to use commands like 'textwidth'.
+--   For instance:
+--
+-- > rule Nothing (CustomMeasure linewidth) (Pt 2)
+--
+-- This will create a black box (see 'rule') as wide as the text and two points tall.
+--
+data Measure a =
+   Pt Double -- ^ A point is 1/72.27 inch, that means about 0.0138 inch or 0.3515 mm.
+ | Mm Double -- ^ Millimeter.
+ | Cm Double -- ^ Centimeter.
+ | In Double -- ^ Inch.
+ | Ex Double -- ^ The height of an \"x\" in the current font.
+ | Em Double -- ^ The width of an \"M\" in the current font.
+ | CustomMeasure (LaTeX a) -- ^ You can introduce a 'LaTeX' expression as a measure.
+   deriving (Data, Eq, Generic, Show, Typeable, Functor)
+
+-- | Different types of syntax for mathematical expressions.
+data MathType = Parentheses | Square | Dollar | DoubleDollar | LHSInline
+  deriving (Data, Eq, Generic, Show, Typeable)
+
+-- | Type of @LaTeX@ blocks. The @a@ type variable can be used for
+-- a number of things but mainly stores source location.
+data LaTeX a =
+   TeXRaw a Text -- ^ Raw text.
+ | TeXComm a String [TeXArg a] -- ^ Constructor for commands.
+                               -- First argument is the name of the command.
+                               -- Second, its arguments.
+ | TeXCommS a String -- ^ Constructor for commands with no arguments.
+                     --   When rendering, no space or @{}@ will be added at
+                     --   the end.
+ | TeXEnv a a String [TeXArg a] (LaTeX a) -- ^ Constructor for environments.
+                                          -- First argument is the name of the environment.
+                                          -- Second, its arguments.
+                                          -- Third, its content.
+ | TeXMath a MathType (LaTeX a) -- ^ Mathematical expressions.
+ | TeXLineBreak a (Maybe (Measure a)) Bool -- ^ Line break command.
+ | TeXBraces a (LaTeX a) -- ^ A expression between braces.
+ | TeXComment a Text -- ^ Comments.
+ | TeXSeq (LaTeX a) (LaTeX a) -- ^ Sequencing of 'LaTeX' expressions.
+                              -- Use '<>' preferably.
+ | TeXEmpty -- ^ An empty block.
+            -- /Neutral element/ of '<>'.
+   deriving (Data, Eq, Generic, Show, Typeable, Functor)
+
+-- | An argument for a 'LaTeX' command or environment.
+data TeXArg a =
+   FixArg a (LaTeX a)  -- ^ Fixed argument.
+ | OptArg a (LaTeX a)  -- ^ Optional argument.
+ | MOptArg a [LaTeX a] -- ^ Multiple optional argument.
+ | SymArg a (LaTeX a)  -- ^ An argument enclosed between @\<@ and @\>@.
+ | MSymArg a [LaTeX a] -- ^ Version of 'SymArg' with multiple options.
+ | ParArg a (LaTeX a)  -- ^ An argument enclosed between @(@ and @)@.
+ | MParArg a [LaTeX a] -- ^ Version of 'ParArg' with multiple options.
+   deriving (Data, Eq, Generic, Show, Typeable, Functor)
+
+-- Monoid instance for 'LaTeX'.
+
+-- | Method 'mappend' is strict in both arguments (except in the case when the first argument is 'TeXEmpty').
+instance Monoid (LaTeX a) where
+ mempty = TeXEmpty
+ mappend TeXEmpty x = x
+ mappend x TeXEmpty = x
+ -- This equation is to make 'mappend' associative.
+ mappend (TeXSeq x y) z = TeXSeq x $ mappend y z
+ --
+ mappend x y = TeXSeq x y
+
+instance Semigroup.Semigroup (LaTeX a) where
+  (<>) = mappend
+
+-- | Calling 'between' @c l1 l2@ puts @c@ between @l1@ and @l2@ and
+--   appends them.
+--
+-- > between c l1 l2 = l1 <> c <> l2
+between :: Monoid m => m -> m -> m -> m
+between c l1 l2 = l1 <> c <> l2
+
+-- | Method 'fromString' escapes LaTeX reserved characters using 'protectString'.
+instance IsString (LaTeX ()) where
+ fromString = TeXRaw () . fromString . protectString
+
+-- | Escape LaTeX reserved characters in a 'String'.
+protectString :: String -> String
+protectString = mconcat . fmap protectChar
+
+-- | Escape LaTeX reserved characters in a 'Text'.
+protectText :: Text -> Text
+protectText = Data.Text.concatMap (fromString . protectChar)
+
+protectChar :: Char -> String
+protectChar '#'  = "\\#"
+protectChar '$'  = "\\$"
+protectChar '%'  = "\\%"
+protectChar '^'  = "\\^{}"
+protectChar '&'  = "\\&"
+protectChar '{'  = "\\{"
+protectChar '}'  = "\\}"
+protectChar '~'  = "\\~{}"
+protectChar '\\' = "\\textbackslash{}"
+protectChar '_'  = "\\_{}"
+protectChar x = [x]
+
+-- Syntax analysis
+
+-- | Look into a 'LaTeX' syntax tree to find any call to the command with
+--   the given name. It returns a list of arguments with which this command
+--   is called.
+--
+-- > lookForCommand = (fmap snd .) . matchCommand . (==)
+--
+--   If the returned list is empty, the command was not found. However,
+--   if the list contains empty lists, those are callings to the command
+--   with no arguments.
+--
+--   For example
+--
+-- > lookForCommand "author" l
+--
+--   would look for the argument passed to the @\\author@ command in @l@.
+lookForCommand :: String  -- ^ Name of the command.
+               -> LaTeX a -- ^ LaTeX syntax tree.
+               -> [[TeXArg a]] -- ^ List of arguments passed to the command.
+lookForCommand = (fmap snd .) . matchCommand . (==)
+
+-- | Traverse a 'LaTeX' syntax tree and returns the commands (see 'TeXComm' and
+--   'TeXCommS') that matches the condition and their arguments in each call.
+matchCommand :: (String -> Bool) -> LaTeX a -> [(String,[TeXArg a])]
+matchCommand f (TeXComm _ str as) =
+  let xs = concatMap (matchCommandArg f) as
+  in  if f str then (str,as) : xs else xs
+matchCommand f (TeXCommS _ str) = [(str, []) | f str]
+matchCommand f (TeXEnv _ _ _ as l) =
+  let xs = concatMap (matchCommandArg f) as
+  in  xs ++ matchCommand f l
+matchCommand f (TeXMath _ _ l) = matchCommand f l
+matchCommand f (TeXBraces _ l) = matchCommand f l
+matchCommand f (TeXSeq l1 l2) = matchCommand f l1 ++ matchCommand f l2
+matchCommand _ _ = []
+
+matchCommandArg :: (String -> Bool) -> TeXArg a -> [(String,[TeXArg a])]
+matchCommandArg f (OptArg  _ l ) = matchCommand f l
+matchCommandArg f (FixArg  _ l ) = matchCommand f l
+matchCommandArg f (MOptArg _ ls) = concatMap (matchCommand f) ls
+matchCommandArg f (SymArg  _ l ) = matchCommand f l
+matchCommandArg f (MSymArg _ ls) = concatMap (matchCommand f) ls
+matchCommandArg f (ParArg  _ l ) = matchCommand f l
+matchCommandArg f (MParArg _ ls) = concatMap (matchCommand f) ls
+
+-- | Similar to 'lookForCommand', but applied to environments.
+--   It returns a list with arguments passed and content of the
+--   environment in each call.
+--
+-- > lookForEnv = (fmap (\(_,as,l) -> (as,l)) .) . matchEnv . (==)
+--
+lookForEnv :: String -> LaTeX a -> [([TeXArg a],LaTeX a)]
+lookForEnv = (fmap (\(_,as,l) -> (as,l)) .) . matchEnv . (==)
+
+-- | Traverse a 'LaTeX' syntax tree and returns the environments (see
+--   'TeXEnv') that matches the condition, their arguments and their content
+--   in each call.
+matchEnv :: (String -> Bool) -> LaTeX a -> [(String,[TeXArg a],LaTeX a)]
+matchEnv f (TeXComm _ _ as) = concatMap (matchEnvArg f) as
+matchEnv f (TeXEnv _ _ str as l) =
+  let xs = concatMap (matchEnvArg f) as
+      ys = matchEnv f l
+      zs = xs ++ ys
+  in  if f str then (str,as,l) : zs else zs
+matchEnv f (TeXMath _ _ l) = matchEnv f l
+matchEnv f (TeXBraces _ l) = matchEnv f l
+matchEnv f (TeXSeq l1 l2) = matchEnv f l1 ++ matchEnv f l2
+matchEnv _ _ = []
+
+matchEnvArg :: (String -> Bool) -> TeXArg a -> [(String,[TeXArg a],LaTeX a)]
+matchEnvArg f (OptArg  _ l ) = matchEnv f l
+matchEnvArg f (FixArg  _ l ) = matchEnv f l
+matchEnvArg f (MOptArg _ ls) = concatMap (matchEnv f) ls
+matchEnvArg f (SymArg  _ l ) = matchEnv f l
+matchEnvArg f (MSymArg _ ls) = concatMap (matchEnv f) ls
+matchEnvArg f (ParArg  _ l ) = matchEnv f l
+matchEnvArg f (MParArg _ ls) = concatMap (matchEnv f) ls
+
+-- | The function 'texmap' looks for subexpressions that match a given
+--   condition and applies a function to them.
+--
+-- > texmap c f = runIdentity . texmapM c (pure . f)
+texmap :: (LaTeX a -> Bool)    -- ^ Condition.
+       -> (LaTeX a -> LaTeX a) -- ^ Function to apply when the condition matches.
+       ->  LaTeX a -> LaTeX a
+texmap c f = runIdentity . texmapM c (pure . f)
+
+-- | Version of 'texmap' where the function returns values in a 'Monad'.
+texmapM :: (Applicative m, Monad m)
+        => (LaTeX a -> Bool) -- ^ Condition.
+        -> (LaTeX a -> m (LaTeX a)) -- ^ Function to apply when the condition matches.
+        ->  LaTeX a -> m (LaTeX a)
+texmapM c f = go
+  where
+   go l@(TeXComm a str as)  = if c l then f l else TeXComm a str <$> mapM go' as
+   go l@(TeXEnv a a' str as b) = if c l then f l else TeXEnv a a' str <$> mapM go' as <*> go b
+   go l@(TeXMath a t b)     = if c l then f l else TeXMath a t <$> go b
+   go l@(TeXBraces a b)     = if c l then f l else TeXBraces a <$> go b
+   go l@(TeXSeq l1 l2)    = if c l then f l else liftA2 TeXSeq (go l1) (go l2)
+   go l = if c l then f l else pure l
+   --
+   go' (FixArg  a l ) = FixArg  a <$> go l
+   go' (OptArg  a l ) = OptArg  a <$> go l
+   go' (MOptArg a ls) = MOptArg a <$> mapM go ls
+   go' (SymArg  a l ) = SymArg  a <$> go l
+   go' (MSymArg a ls) = MSymArg a <$> mapM go ls
+   go' (ParArg  a l ) = ParArg  a <$> go l
+   go' (MParArg a ls) = MParArg a <$> mapM go ls
+
+-- | Extract the content of the 'document' environment, if present.
+getBody :: LaTeX a -> Maybe (LaTeX a)
+getBody l =
+  case lookForEnv "document" l of
+    ((_,b):_) -> Just b
+    _ -> Nothing
+
+-- | Extract the preamble of a 'LaTeX' document (everything before the 'document'
+--   environment). It could be empty.
+getPreamble :: LaTeX a -> LaTeX a
+getPreamble (TeXEnv _ _ "document" _ _) = mempty
+getPreamble (TeXSeq l1 l2) = getPreamble l1 <> getPreamble l2
+getPreamble l = l
+
+---------------------------------------
+-- LaTeX Arbitrary instance
+
+arbitraryChar :: Gen Char
+arbitraryChar = elements $
+     ['A'..'Z']
+  ++ ['a'..'z']
+  ++ "\n-+*/!\"().,:;'@<>? "
+
+-- | Utility for the instance of 'LaTeX' to 'Arbitrary'.
+--   We generate a short sequence of characters and
+--   escape reserved characters with 'protectText'.
+arbitraryRaw :: Gen Text
+arbitraryRaw = do
+  n <- choose (1,20)
+  protectText . pack <$> replicateM n arbitraryChar
+
+-- | Generator for names of command and environments.
+--   We use only alphabetical characters.
+arbitraryName :: Gen String
+arbitraryName = do
+  n <- choose (1,10)
+  replicateM n $ elements $ ['a' .. 'z'] ++ ['A' .. 'Z']
+
+instance Arbitrary (Measure a) where
+  arbitrary = do
+     n <- choose (0,5)
+     let f = [Pt,Mm,Cm,In,Ex,Em] !! n
+     f <$> arbitrary
+
+instance Arbitrary a => Arbitrary (LaTeX a) where
+  arbitrary = arbitraryLaTeX False
+
+arbitraryLaTeX :: Arbitrary a => Bool -> Gen (LaTeX a)
+arbitraryLaTeX inDollar = do
+  -- We give more chances to 'TeXRaw'.
+  -- This results in arbitrary 'LaTeX' values
+  -- not getting too large.
+  n <- choose (0,16 :: Int)
+  case n of
+    0 -> if inDollar then arbitraryLaTeX True else pure TeXEmpty
+    1 -> do m <- choose (0,5)
+            TeXComm <$> arbitrary <*> arbitraryName <*> vectorOf m arbitrary
+    2 -> TeXCommS <$> arbitrary <*> arbitraryName
+    3 -> do m <- choose (0,5)
+            TeXEnv <$> arbitrary <*> arbitrary <*> arbitraryName <*> vectorOf m arbitrary <*> arbitrary
+    4 -> if inDollar
+            then arbitraryLaTeX True
+            else do m <- choose (0,3)
+                    let t = [Parentheses,Square,Dollar,DoubleDollar] !! m
+                    TeXMath <$> arbitrary <*> pure t <*> arbitraryLaTeX (t == Dollar || t == DoubleDollar)
+    5 -> TeXLineBreak <$> arbitrary <*> arbitrary <*> arbitrary
+    6 -> TeXBraces <$> arbitrary <*> arbitrary
+    7 -> TeXComment <$> arbitrary <*> arbitraryRaw
+    8 -> TeXSeq <$> (if inDollar then arbitraryLaTeX True else arbitrary) <*> arbitrary
+    _ -> TeXRaw <$> arbitrary <*> arbitraryRaw
+
+instance Arbitrary a => Arbitrary (TeXArg a) where
+  arbitrary = do
+     n <- choose (0,6 :: Int)
+     case n of
+       0 -> OptArg <$> arbitrary <*> arbitrary
+       1 -> do m <- choose (1,5)
+               MOptArg <$> arbitrary <*> vectorOf m arbitrary
+       2 -> SymArg <$> arbitrary <*> arbitrary
+       3 -> do m <- choose (1,5)
+               MSymArg <$> arbitrary <*> vectorOf m arbitrary
+       4 -> ParArg <$> arbitrary <*> arbitrary
+       5 -> do m <- choose (1,5)
+               MParArg <$> arbitrary <*> vectorOf m arbitrary
+       _ -> FixArg <$> arbitrary <*> arbitrary
+
+
+instance Hashable a => Hashable (Measure a)
+instance Hashable MathType
+instance Hashable a => Hashable (TeXArg a)
+instance Hashable a => Hashable (LaTeX a)

--- a/Text/LaTeX/Base/Texy.hs
+++ b/Text/LaTeX/Base/Texy.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances , TypeSynonymInstances #-}
 
 -- | 'Texy' class, as proposed in <http://deltadiaz.blogspot.com.es/2013/04/hatex-36-proposal-texy-class.html>.
 module Text.LaTeX.Base.Texy (

--- a/Text/LaTeX/Base/Types.hs
+++ b/Text/LaTeX/Base/Types.hs
@@ -1,5 +1,4 @@
-
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings , PatternSynonyms #-}
 
 -- | Some types shared along the library.
 module Text.LaTeX.Base.Types (
@@ -10,7 +9,8 @@ module Text.LaTeX.Base.Types (
  , createLabel , labelName
  , Pos (..) , HPos (..)
  , TableSpec (..)
- , Measure (..)
+ , Measure , pattern Pt , pattern Mm , pattern Cm , pattern In
+ , pattern Ex , pattern Em , pattern CustomMeasure
  ) where
 
 import Text.LaTeX.Base.Syntax

--- a/Text/LaTeX/Packages/Acronym.hs
+++ b/Text/LaTeX/Packages/Acronym.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings, CPP , PatternSynonyms #-}
 
 -- | Add acronyms to your documents using this module.
 --
@@ -24,7 +24,7 @@ module Text.LaTeX.Packages.Acronym
 import Data.String(IsString(fromString))
 
 import Text.LaTeX.Base.Class(LaTeXC, comm0, comm1, comm2, liftL, liftL2)
-import Text.LaTeX.Base.Syntax(LaTeX(TeXComm, TeXEnv), TeXArg(FixArg, OptArg))
+import Text.LaTeX.Base.Syntax
 import Text.LaTeX.Base.Types(PackageName)
 import Text.LaTeX.Base.Writer(LaTeXT)
 

--- a/Text/LaTeX/Packages/Bigstrut.hs
+++ b/Text/LaTeX/Packages/Bigstrut.hs
@@ -11,7 +11,7 @@ module Text.LaTeX.Packages.Bigstrut
  , bigstrutBottom
  ) where
 
-import Text.LaTeX.Base.Syntax (LaTeX(TeXComm), TeXArg(OptArg))
+import Text.LaTeX.Base.Syntax 
 import Text.LaTeX.Base.Class (LaTeXC, fromLaTeX)
 import Text.LaTeX.Base.Types (PackageName)
 

--- a/Text/LaTeX/Packages/LTableX.hs
+++ b/Text/LaTeX/Packages/LTableX.hs
@@ -11,7 +11,7 @@ module Text.LaTeX.Packages.LTableX
  , module Text.LaTeX.Packages.LongTable
  ) where
 
-import Text.LaTeX.Base.Syntax (LaTeX(TeXComm))
+import Text.LaTeX.Base.Syntax 
 import Text.LaTeX.Base.Class (LaTeXC, fromLaTeX)
 import Text.LaTeX.Base.Types (PackageName)
 import Text.LaTeX.Packages.TabularX (tabularx)

--- a/Text/LaTeX/Packages/LongTable.hs
+++ b/Text/LaTeX/Packages/LongTable.hs
@@ -13,7 +13,7 @@ module Text.LaTeX.Packages.LongTable
    -- * Package Options
    ) where
 
-import Text.LaTeX.Base.Syntax (LaTeX(TeXEnv, TeXRaw, TeXComm), TeXArg(FixArg, OptArg))
+import Text.LaTeX.Base.Syntax
 import Text.LaTeX.Base.Class (LaTeXC, fromLaTeX, liftL)
 import Text.LaTeX.Base.Render (render, renderAppend)
 import Text.LaTeX.Base.Types (PackageName, Pos, TableSpec)

--- a/Text/LaTeX/Packages/Lscape.hs
+++ b/Text/LaTeX/Packages/Lscape.hs
@@ -9,7 +9,7 @@ module Text.LaTeX.Packages.Lscape
  , pdftex
  ) where
 
-import Text.LaTeX.Base.Syntax (LaTeX(TeXEnv))
+import Text.LaTeX.Base.Syntax
 import Text.LaTeX.Base.Class (LaTeXC, liftL)
 import Text.LaTeX.Base.Types (PackageName)
 

--- a/Text/LaTeX/Packages/Multirow.hs
+++ b/Text/LaTeX/Packages/Multirow.hs
@@ -12,7 +12,7 @@ module Text.LaTeX.Packages.Multirow
 
 import qualified Data.Semigroup as SG ((<>))
 import Data.Maybe (catMaybes)
-import Text.LaTeX.Base.Syntax (LaTeX(TeXComm), TeXArg(FixArg, OptArg))
+import Text.LaTeX.Base.Syntax
 import Text.LaTeX.Base.Class (LaTeXC, liftL)
 import Text.LaTeX.Base.Types (PackageName, Pos, Measure)
 import Text.LaTeX.Base.Render (Render, render, rendertex)

--- a/Text/LaTeX/Packages/TabularX.hs
+++ b/Text/LaTeX/Packages/TabularX.hs
@@ -8,7 +8,7 @@ module Text.LaTeX.Packages.TabularX
  , tabularx
  ) where
 
-import Text.LaTeX.Base.Syntax (LaTeX(TeXEnv, TeXRaw), TeXArg(FixArg, OptArg))
+import Text.LaTeX.Base.Syntax
 import Text.LaTeX.Base.Class (LaTeXC, liftL)
 import Text.LaTeX.Base.Render (render, renderAppend)
 import Text.LaTeX.Base.Types (PackageName, Pos, TableSpec, Measure)


### PR DESCRIPTION
I just made a quick sketch of parametrize the AST with data that would support the addition of source location tokens (#148). The libary builds fine and the tests pass. :+1: 

I don't necessarily like the amount of pattern synonyms in `Text.LaTeX.Base.Syntax` nor the fact that to import non-annotated AST variants one would have to use `-XPatternSynonyms` and write `pattern` explicitly. For example, in `Text.LaTeX.Packages.Acronym` the import line:

```haskell
import Text.LaTeX.Base.Syntax(LaTeX(TeXComm, TeXEnv), TeXArg(FixArg, OptArg))
```

Would have to become:
```haskell
import Text.LaTeX.Base.Syntax(LaTeX , pattern TeXComm, pattern TeXEnv, TeXArg, pattern FixArg, pattern OptArg)
```
Instead, I just imported the whole `Syntax` module: `import Text.LaTeX.Base.Syntax`
