### PR TITLE
Allow bytestring version 0.11

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -57,7 +57,7 @@ Source-repository head
 Library
   Default-language: Haskell2010
   Build-depends: base == 4.*
-               , bytestring >= 0.9.2.1 && < 0.11
+               , bytestring >= 0.9.2.1 && < 0.12
                , text >= 0.11.2.3 && < 2
                , transformers >= 0.2.2 && < 0.6
                , containers >= 0.4.2.1 && < 0.7


### PR DESCRIPTION
Fixes #152.

Tested using 'cabal test'.

The line has a carriage return since that was auto-detected by NeoVIM. If you want the the file with Unix newlines, I can change the whole file using dos2unix.
