### PR TITLE
Allow hashable 1.4.* and text 2.0.*

### DIFF
--- a/HaTeX.cabal
+++ b/HaTeX.cabal
@@ -58,10 +58,10 @@ Library
   Default-language: Haskell2010
   Build-depends: base == 4.*
                , bytestring >= 0.9.2.1 && < 0.12
-               , text >= 0.11.2.3 && < 2
+               , text >= 0.11.2.3 && < 2.1
                , transformers >= 0.2.2 && < 0.6
                , containers >= 0.4.2.1 && < 0.7
-               , hashable >= 1.2 && < 1.4
+               , hashable >= 1.2 && < 1.5
                , bibtex >= 0.1 && < 0.2
                , matrix
                  -- Testing


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' --constraint='hashable>=1.4'
